### PR TITLE
Fix email parser

### DIFF
--- a/MarkdigAutoEmail.Test/AutoEmailLinkingExtensionTest.cs
+++ b/MarkdigAutoEmail.Test/AutoEmailLinkingExtensionTest.cs
@@ -13,7 +13,7 @@ namespace MarkdigAutoEmail.Test
         [InlineData("Please ask **someone@example.com**", @"<p>Please ask <strong><a href=""mailto:someone@example.com"">someone@example.com</a></strong></p>")]
         [InlineData("someone@example.com is the person to get in touch with", @"<p><a href=""mailto:someone@example.com"">someone@example.com</a> is the person to get in touch with</p>")]
         [InlineData(@"Leave <a href=""mailto:foo@example.com"">foo@example.com</a> existing  links alone", @"<p>Leave <a href=""mailto:foo@example.com"">foo@example.com</a> existing  links alone</p>")]
-        [InlineData("Send an email to someonee@example.com", @"<p>Send an email to <a href=""mailto:someone@example.com"">someone.else@example.com</a></p>")]
+        [InlineData("Send an email to someone@example.com", @"<p>Send an email to <a href=""mailto:someone@example.com"">someone@example.com</a></p>")]
         public void ShouldAutoLinkEmailOnStart(string markdown, string expectedHtml)
         {
             var markdownPipeline = new MarkdownPipelineBuilder()


### PR DESCRIPTION
This is an example of a fix for the email parser.

In fact inline parsers require `OpeningCharacters` to work correctly because the default inline parser (the one that grab any text if no other inline parsers matched  is actually going to rely on other opening characters to decide how far it can go to pickup characters - That's an optimization but it brings a constraint to the inline parsers)

So the fix is assuming a fixed set of opening characters. You might have to adjust these characters to the list of all valid email characters.

I fixed also the trailing `>` which was not removed and the content of the inline.